### PR TITLE
Use ESA dependency and features-bom

### DIFF
--- a/finish/pom.xml
+++ b/finish/pom.xml
@@ -19,6 +19,18 @@
         <packaging.type>usr</packaging.type>
     </properties>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.openliberty.features</groupId>
+                <artifactId>features-bom</artifactId>
+                <version>18.0.0.2</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+    
     <dependencies>
         <dependency>
             <groupId>junit</groupId>
@@ -27,15 +39,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>javax.ws.rs-api</artifactId>
-            <version>2.0.1</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.ibm.websphere.appserver.api</groupId>
-            <artifactId>com.ibm.websphere.appserver.api.jaxrs20</artifactId>
-            <version>1.0.10</version>
+            <groupId>io.openliberty.features</groupId>
+            <artifactId>jaxrs-2.0</artifactId>
+            <type>esa</type>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/finish/pom.xml
+++ b/finish/pom.xml
@@ -19,12 +19,20 @@
         <packaging.type>usr</packaging.type>
     </properties>
 
+    <repositories>
+        <repository>
+            <id>features</id>
+            <name>features</name>
+            <url>http://rtpgsa.ibm.com/home/w/a/wasngi/web/public/maven/</url>
+        </repository>
+    </repositories>
+
     <dependencyManagement>
         <dependencies>
             <dependency>
                 <groupId>io.openliberty.features</groupId>
                 <artifactId>features-bom</artifactId>
-                <version>RELEASE</version>
+                <version>18.0.0.3</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -105,7 +113,7 @@
                     <assemblyArtifact>
                         <groupId>io.openliberty</groupId>
                         <artifactId>openliberty-kernel</artifactId>
-                        <version>RELEASE</version>
+                        <version>18.0.0.3</version>
                         <type>zip</type>
                     </assemblyArtifact>
                     <configFile>src/main/liberty/config/server.xml</configFile>

--- a/finish/pom.xml
+++ b/finish/pom.xml
@@ -24,13 +24,13 @@
             <dependency>
                 <groupId>io.openliberty.features</groupId>
                 <artifactId>features-bom</artifactId>
-                <version>18.0.0.2</version>
+                <version>RELEASE</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>
-    
+
     <dependencies>
         <dependency>
             <groupId>junit</groupId>
@@ -100,11 +100,11 @@
             <plugin>
                 <groupId>net.wasdev.wlp.maven.plugins</groupId>
                 <artifactId>liberty-maven-plugin</artifactId>
-                <version>2.4</version>
+                <version>2.5</version>
                 <configuration>
                     <assemblyArtifact>
                         <groupId>io.openliberty</groupId>
-                        <artifactId>openliberty-runtime</artifactId>
+                        <artifactId>openliberty-kernel</artifactId>
                         <version>RELEASE</version>
                         <type>zip</type>
                     </assemblyArtifact>
@@ -123,6 +123,18 @@
                         <goals>
                             <goal>install-server</goal>
                         </goals>
+                    </execution>
+                    <execution>
+                        <id>install-feature</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>install-feature</goal>
+                        </goals>
+                        <configuration>
+                            <features>
+                                <acceptLicense>true</acceptLicense>
+                            </features>
+                        </configuration>
                     </execution>
                     <execution>
                         <id>install-app</id>

--- a/finish/pom.xml
+++ b/finish/pom.xml
@@ -19,20 +19,12 @@
         <packaging.type>usr</packaging.type>
     </properties>
 
-    <repositories>
-        <repository>
-            <id>features</id>
-            <name>features</name>
-            <url>http://rtpgsa.ibm.com/home/w/a/wasngi/web/public/maven/</url>
-        </repository>
-    </repositories>
-
     <dependencyManagement>
         <dependencies>
             <dependency>
                 <groupId>io.openliberty.features</groupId>
                 <artifactId>features-bom</artifactId>
-                <version>18.0.0.3</version>
+                <version>RELEASE</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -56,21 +48,25 @@
             <groupId>javax.xml.bind</groupId>
             <artifactId>jaxb-api</artifactId>
             <version>2.2.11</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.sun.xml.bind</groupId>
             <artifactId>jaxb-core</artifactId>
             <version>2.2.11</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.sun.xml.bind</groupId>
             <artifactId>jaxb-impl</artifactId>
             <version>2.2.11</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>javax.activation</groupId>
             <artifactId>activation</artifactId>
             <version>1.1.1</version>
+            <scope>test</scope>
         </dependency>
 
     </dependencies>
@@ -113,7 +109,7 @@
                     <assemblyArtifact>
                         <groupId>io.openliberty</groupId>
                         <artifactId>openliberty-kernel</artifactId>
-                        <version>18.0.0.3</version>
+                        <version>RELEASE</version>
                         <type>zip</type>
                     </assemblyArtifact>
                     <configFile>src/main/liberty/config/server.xml</configFile>

--- a/start/pom.xml
+++ b/start/pom.xml
@@ -19,20 +19,12 @@
         <packaging.type>usr</packaging.type>
     </properties>
 
-    <repositories>
-        <repository>
-            <id>features</id>
-            <name>features</name>
-            <url>http://rtpgsa.ibm.com/home/w/a/wasngi/web/public/maven/</url>
-        </repository>
-    </repositories>
-    
     <dependencyManagement>
         <dependencies>
             <dependency>
                 <groupId>io.openliberty.features</groupId>
                 <artifactId>features-bom</artifactId>
-                <version>18.0.0.3</version>
+                <version>RELEASE</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -56,21 +48,25 @@
             <groupId>javax.xml.bind</groupId>
             <artifactId>jaxb-api</artifactId>
             <version>2.2.11</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.sun.xml.bind</groupId>
             <artifactId>jaxb-core</artifactId>
             <version>2.2.11</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.sun.xml.bind</groupId>
             <artifactId>jaxb-impl</artifactId>
             <version>2.2.11</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>javax.activation</groupId>
             <artifactId>activation</artifactId>
             <version>1.1.1</version>
+            <scope>test</scope>
         </dependency>
 
     </dependencies>
@@ -113,7 +109,7 @@
                     <assemblyArtifact>
                         <groupId>io.openliberty</groupId>
                         <artifactId>openliberty-kernel</artifactId>
-                        <version>18.0.0.3</version>
+                        <version>RELEASE</version>
                         <type>zip</type>
                     </assemblyArtifact>
                     <configFile>src/main/liberty/config/server.xml</configFile>
@@ -126,6 +122,13 @@
                 </configuration>
                 <executions>
                     <execution>
+                        <id>install-liberty</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>install-server</goal>
+                        </goals>
+                    </execution>
+                    <execution>
                         <id>install-feature</id>
                         <phase>prepare-package</phase>
                         <goals>
@@ -136,13 +139,6 @@
                                 <acceptLicense>true</acceptLicense>
                             </features>
                         </configuration>
-                    </execution>
-                    <execution>
-                        <id>install-liberty</id>
-                        <phase>prepare-package</phase>
-                        <goals>
-                            <goal>install-server</goal>
-                        </goals>
                     </execution>
                     <execution>
                         <id>install-app</id>

--- a/start/pom.xml
+++ b/start/pom.xml
@@ -19,6 +19,18 @@
         <packaging.type>usr</packaging.type>
     </properties>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.openliberty.features</groupId>
+                <artifactId>features-bom</artifactId>
+                <version>18.0.0.2</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>junit</groupId>
@@ -27,15 +39,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>javax.ws.rs-api</artifactId>
-            <version>2.0.1</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.ibm.websphere.appserver.api</groupId>
-            <artifactId>com.ibm.websphere.appserver.api.jaxrs20</artifactId>
-            <version>1.0.10</version>
+            <groupId>io.openliberty.features</groupId>
+            <artifactId>jaxrs-2.0</artifactId>
+            <type>esa</type>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/start/pom.xml
+++ b/start/pom.xml
@@ -19,12 +19,20 @@
         <packaging.type>usr</packaging.type>
     </properties>
 
+    <repositories>
+        <repository>
+            <id>features</id>
+            <name>features</name>
+            <url>http://rtpgsa.ibm.com/home/w/a/wasngi/web/public/maven/</url>
+        </repository>
+    </repositories>
+    
     <dependencyManagement>
         <dependencies>
             <dependency>
                 <groupId>io.openliberty.features</groupId>
                 <artifactId>features-bom</artifactId>
-                <version>RELEASE</version>
+                <version>18.0.0.3</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -105,7 +113,7 @@
                     <assemblyArtifact>
                         <groupId>io.openliberty</groupId>
                         <artifactId>openliberty-kernel</artifactId>
-                        <version>RELEASE</version>
+                        <version>18.0.0.3</version>
                         <type>zip</type>
                     </assemblyArtifact>
                     <configFile>src/main/liberty/config/server.xml</configFile>

--- a/start/pom.xml
+++ b/start/pom.xml
@@ -24,7 +24,7 @@
             <dependency>
                 <groupId>io.openliberty.features</groupId>
                 <artifactId>features-bom</artifactId>
-                <version>18.0.0.2</version>
+                <version>RELEASE</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -100,11 +100,11 @@
             <plugin>
                 <groupId>net.wasdev.wlp.maven.plugins</groupId>
                 <artifactId>liberty-maven-plugin</artifactId>
-                <version>2.4</version>
+                <version>2.5</version>
                 <configuration>
                     <assemblyArtifact>
                         <groupId>io.openliberty</groupId>
-                        <artifactId>openliberty-runtime</artifactId>
+                        <artifactId>openliberty-kernel</artifactId>
                         <version>RELEASE</version>
                         <type>zip</type>
                     </assemblyArtifact>
@@ -117,6 +117,18 @@
                     </bootstrapProperties>
                 </configuration>
                 <executions>
+                    <execution>
+                        <id>install-feature</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>install-feature</goal>
+                        </goals>
+                        <configuration>
+                            <features>
+                                <acceptLicense>true</acceptLicense>
+                            </features>
+                        </configuration>
+                    </execution>
                     <execution>
                         <id>install-liberty</id>
                         <phase>prepare-package</phase>


### PR DESCRIPTION
This pull request updates the project pom.xml file to replace all the dependencies with imported scope with the esa feature dependencies, and provides an alternative to use openliberty-kernel runtime with only the required features installed from the esa feature dependencies using the Liberty Maven plugin install-feature goal.

The esa feature dependency will automatically pull the feature's spec api, server api/spi dependencies for building the project.